### PR TITLE
Configure Gradle settings for Flutter plugin management

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
-
 def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
 def properties = new Properties()
-
 assert localPropertiesFile.exists()
 localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
-
 def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+
+includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id("dev.flutter.flutter-plugin-loader") version "1.0.0"
+    id("com.android.application") version "8.7.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
+}
+
+include(":app")


### PR DESCRIPTION
## Summary
- load the Flutter SDK path from `local.properties` and include the flutter tools composite build
- declare plugin management repositories and configure required Gradle plugins in `settings.gradle`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d93cb3a8c48332b372dfd35511666f