### PR TITLE
Refine Gradle settings structure

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,13 +1,13 @@
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-
-includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
-
 pluginManagement {
+    def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
+    def properties = new Properties()
+    assert localPropertiesFile.exists()
+    localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    def flutterSdkPath = properties.getProperty("flutter.sdk")
+    assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary
- move Flutter SDK discovery and includeBuild logic inside the pluginManagement block
- ensure the plugin definitions follow pluginManagement with include(":app") at the end

## Testing
- ./gradlew help *(fails: Unable to tunnel through proxy to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d940de64ec8332b38d9afc1181f7e6