### PR TITLE
refactor: align android gradle setup with flutter 3.35

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -21,8 +21,10 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
+def kotlinVersion = '1.9.24'
+
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
+apply plugin: 'org.jetbrains.kotlin.android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 def keystorePropertiesFile = rootProject.file("key.properties")
@@ -92,7 +94,7 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation 'com.google.firebase:firebase-core:21.1.1'
     implementation 'com.google.firebase:firebase-messaging:24.0.1'
     implementation 'androidx.arch.core:core-runtime:2.2.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,46 +1,20 @@
-buildscript {
-    ext.kotlin_version = '1.9.24' // Updated to a more recent version
-    repositories {
-        google()
-        mavenCentral() 
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.0'
-        classpath 'com.google.gms:google-services:4.4.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        // classpath 'androidx.lifecycle:lifecycle-viewmodel-savedstate:2.5.1'
-    }
+plugins {
+    id 'com.android.application' version '8.7.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
+    id 'dev.flutter.flutter-plugin-loader' version '1.0.0' apply false
+    id 'com.google.gms.google-services' version '4.4.2' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral() // Updated to use mavenCentral()
-    }
- // This code is where all the magic happens and fixes the error.
-    subprojects {
-        afterEvaluate { project ->
-            if (project.hasProperty('android')) {
-                project.android {
-                    if (namespace == null) {
-                        namespace project.group
-                    }
+subprojects {
+    afterEvaluate { project ->
+        if (project.hasProperty('android')) {
+            project.android {
+                if (namespace == null) {
+                    namespace project.group
                 }
             }
         }
     }
-    // This code is where all the magic happens and fixes the error.
-    // subprojects {
-    //     project.configurations.configureEach {
-    //         resolutionStrategy.eachDependency { details ->
-    //             if (details.requested.group == 'androidx.lifecycle' && 
-    //                 !details.requested.name.contains('multidex')) {
-    //                 details.useVersion "2.5.1" // Use androidx.lifecycle instead
-    //             }
-    //         }
-    //     }
-    // }
 }
 
 rootProject.buildDir = '../build'

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -15,6 +15,14 @@ pluginManagement {
     }
 }
 
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.0" apply false


### PR DESCRIPTION
## Summary
- replace the root Gradle buildscript with a plugins block using the Flutter 3.35 plugin versions and keep the existing shared task configuration
- scope the Kotlin version to the app module while updating it to use the org.jetbrains.kotlin.android plugin id
- move the shared repository definitions into settings.gradle via dependencyResolutionManagement per the Flutter template

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9418031bc8332be447724634aad49