### PR TITLE
Update Flutter Android app Gradle plugins

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,14 +1,16 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+    id 'dev.flutter.flutter-gradle-plugin'
+    id 'com.google.gms.google-services'
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -22,10 +24,6 @@ if (flutterVersionName == null) {
 }
 
 def kotlinVersion = '1.9.24'
-
-apply plugin: 'com.android.application'
-apply plugin: 'org.jetbrains.kotlin.android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 def keystorePropertiesFile = rootProject.file("key.properties")
 def keystoreProperties = new Properties()
@@ -89,10 +87,6 @@ android {
     }
 }
 
-flutter {
-    source '../..'
-}
-
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation 'com.google.firebase:firebase-core:21.1.1'
@@ -105,8 +99,6 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }
-
-apply plugin: 'com.google.gms.google-services'
 
 // Work around required for removing play-services-measurement
 //com.google.gms.googleservices.GoogleServicesPlugin.config.disableVersionCheck = true


### PR DESCRIPTION
## Summary
- replace legacy apply-plugin calls with the modern plugins DSL for the Android app module
- drop the manual Flutter SDK lookup and flutter { source } block now provided by the new Flutter Gradle plugin
- keep the Kotlin stdlib dependency working by declaring the kotlin_version value locally

## Testing
- bash gradlew help *(fails: Gradle wrapper could not download due to HTTP 403 from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d9485524888332b635779248cd3607