### PR TITLE
Adjust chat bubble timestamp formatting

### DIFF
--- a/lib/widget/chat_bubble_experiment.dart
+++ b/lib/widget/chat_bubble_experiment.dart
@@ -27,7 +27,20 @@ class ChatBubbleExperiment extends StatelessWidget {
 
     }
     link=FunctionUtils.extractMediaLink(message.msg)??'';
-    var dateFormatter = new DateFormat("HH:mm, dd/MM/yy");
+    final messageDateTime =
+        DateTime.fromMillisecondsSinceEpoch(message.time! * 1000);
+    final now = DateTime.now();
+
+    final String formattedTimestamp;
+    if (DateUtils.isSameDay(messageDateTime, now)) {
+      formattedTimestamp = DateFormat('HH:mm').format(messageDateTime);
+    } else if (messageDateTime.year == now.year) {
+      formattedTimestamp =
+          DateFormat('HH:mm, dd/MM').format(messageDateTime);
+    } else {
+      formattedTimestamp =
+          DateFormat('HH:mm, dd/MM/yy').format(messageDateTime);
+    }
 
     final bg = message.user_id == 0 || (message.is_owner == 2)
         ? Colors.grey[300]
@@ -108,8 +121,7 @@ class ChatBubbleExperiment extends StatelessWidget {
                 Padding(
                   padding: const EdgeInsets.only(left: 20.0),
                   child: Text(
-                    dateFormatter.format(DateTime.fromMillisecondsSinceEpoch(
-                        message.time! * 1000)),
+                    formattedTimestamp,
                     style: const TextStyle(
                       color: Colors.black38,
                       fontSize: 10.0,


### PR DESCRIPTION
## Summary
- add contextual timestamp formatting for chat bubbles based on day and year

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9d644d8a88332b8323f7cb9c288cc